### PR TITLE
Set homepage to 2026 save-the-date mode

### DIFF
--- a/generated-styles.css
+++ b/generated-styles.css
@@ -191,21 +191,6 @@
   }
 }
 @layer utilities {
-  .absolute {
-    position: absolute;
-  }
-  .relative {
-    position: relative;
-  }
-  .top-1\/2 {
-    top: calc(1/2 * 100%);
-  }
-  .left-1\/2 {
-    left: calc(1/2 * 100%);
-  }
-  .z-0 {
-    z-index: 0;
-  }
   .z-20 {
     z-index: 20;
   }
@@ -227,17 +212,11 @@
       max-width: 96rem;
     }
   }
-  .m-0 {
-    margin: calc(var(--spacing) * 0);
-  }
   .mx-auto {
     margin-inline: auto;
   }
   .mt-8 {
     margin-top: calc(var(--spacing) * 8);
-  }
-  .mb-1 {
-    margin-bottom: calc(var(--spacing) * 1);
   }
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
@@ -263,9 +242,6 @@
   .ml-2 {
     margin-left: calc(var(--spacing) * 2);
   }
-  .ml-4 {
-    margin-left: calc(var(--spacing) * 4);
-  }
   .ml-auto {
     margin-left: auto;
   }
@@ -284,14 +260,8 @@
   .h-24 {
     height: calc(var(--spacing) * 24);
   }
-  .w-1\/2 {
-    width: calc(1/2 * 100%);
-  }
   .w-24 {
     width: calc(var(--spacing) * 24);
-  }
-  .w-48 {
-    width: calc(var(--spacing) * 48);
   }
   .w-full {
     width: 100%;
@@ -305,9 +275,6 @@
   .max-w-lg {
     max-width: var(--container-lg);
   }
-  .max-w-md {
-    max-width: var(--container-md);
-  }
   .max-w-screen-lg {
     max-width: var(--breakpoint-lg);
   }
@@ -320,19 +287,8 @@
   .max-w-xl {
     max-width: var(--container-xl);
   }
-  .max-w-xs {
-    max-width: var(--container-xs);
-  }
   .shrink-0 {
     flex-shrink: 0;
-  }
-  .-translate-1\/2 {
-    --tw-translate-x: calc(calc(1/2 * 100%) * -1);
-    --tw-translate-y: calc(calc(1/2 * 100%) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
-  .-rotate-10 {
-    rotate: calc(10deg * -1);
   }
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
@@ -379,9 +335,6 @@
   .gap-12 {
     gap: calc(var(--spacing) * 12);
   }
-  .gap-16 {
-    gap: calc(var(--spacing) * 16);
-  }
   .scroll-smooth {
     scroll-behavior: smooth;
   }
@@ -399,14 +352,6 @@
     border-style: var(--tw-border-style);
     border-width: 2px;
   }
-  .border-16 {
-    border-style: var(--tw-border-style);
-    border-width: 16px;
-  }
-  .border-b-2 {
-    border-bottom-style: var(--tw-border-style);
-    border-bottom-width: 2px;
-  }
   .border-b-4 {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 4px;
@@ -417,17 +362,11 @@
   .border-\[\#4ca761\] {
     border-color: #4ca761;
   }
-  .border-\[\#b84b3e\] {
-    border-color: #b84b3e;
-  }
   .border-\[\#fab31b\] {
     border-color: #fab31b;
   }
   .border-b-\[\#9cbc9c\] {
     border-bottom-color: #9cbc9c;
-  }
-  .bg-\[\#00ab5a\] {
-    background-color: #00ab5a;
   }
   .bg-\[\#4ca761\] {
     background-color: #4ca761;
@@ -456,17 +395,11 @@
   .bg-amber-950 {
     background-color: var(--color-amber-950);
   }
-  .bg-black {
-    background-color: var(--color-black);
-  }
   .bg-green-500 {
     background-color: var(--color-green-500);
   }
   .bg-white {
     background-color: var(--color-white);
-  }
-  .p-2 {
-    padding: calc(var(--spacing) * 2);
   }
   .p-4 {
     padding: calc(var(--spacing) * 4);
@@ -541,17 +474,9 @@
     font-size: var(--text-lg);
     line-height: var(--tw-leading, var(--text-lg--line-height));
   }
-  .text-lg\/5 {
-    font-size: var(--text-lg);
-    line-height: calc(var(--spacing) * 5);
-  }
   .text-lg\/6 {
     font-size: var(--text-lg);
     line-height: calc(var(--spacing) * 6);
-  }
-  .text-sm {
-    font-size: var(--text-sm);
-    line-height: var(--tw-leading, var(--text-sm--line-height));
   }
   .text-xl {
     font-size: var(--text-xl);
@@ -571,9 +496,6 @@
   }
   .text-\[\#00ab5a\] {
     color: #00ab5a;
-  }
-  .text-\[\#4ca761\] {
-    color: #4ca761;
   }
   .text-\[\#242c4c\] {
     color: #242c4c;
@@ -605,9 +527,6 @@
   .decoration-\[\#b84b3e\] {
     text-decoration-color: #b84b3e;
   }
-  .decoration-\[\#db311d\] {
-    text-decoration-color: #db311d;
-  }
   .decoration-amber-50 {
     text-decoration-color: var(--color-amber-50);
   }
@@ -629,20 +548,9 @@
   .opacity-50 {
     opacity: 50%;
   }
-  .shadow-2xl {
-    --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
-    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
   .shadow-md {
     --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
-  .hover\:border-\[\#318946\] {
-    &:hover {
-      @media (hover: hover) {
-        border-color: #318946;
-      }
-    }
   }
   .hover\:bg-\[\#318946\] {
     &:hover {
@@ -679,23 +587,14 @@
       }
     }
   }
-  .hover\:text-\[\#fef0e5\] {
-    &:hover {
-      @media (hover: hover) {
-        color: #fef0e5;
-      }
-    }
-  }
-  .hover\:underline {
-    &:hover {
-      @media (hover: hover) {
-        text-decoration-line: underline;
-      }
-    }
-  }
   .sm\:ml-0 {
     @media (width >= 40rem) {
       margin-left: calc(var(--spacing) * 0);
+    }
+  }
+  .sm\:block {
+    @media (width >= 40rem) {
+      display: block;
     }
   }
   .sm\:hidden {
@@ -716,11 +615,6 @@
   .sm\:w-auto {
     @media (width >= 40rem) {
       width: auto;
-    }
-  }
-  .sm\:justify-start {
-    @media (width >= 40rem) {
-      justify-content: flex-start;
     }
   }
   .sm\:px-2 {
@@ -897,12 +791,6 @@
       padding-block: calc(var(--spacing) * 0.5);
     }
   }
-  .lg\:text-2xl {
-    @media (width >= 64rem) {
-      font-size: var(--text-2xl);
-      line-height: var(--tw-leading, var(--text-2xl--line-height));
-    }
-  }
   .lg\:text-4xl {
     @media (width >= 64rem) {
       font-size: var(--text-4xl);
@@ -944,21 +832,6 @@ html {
   font-optical-sizing: auto;
   font-weight: 400;
   font-style: normal;
-}
-@property --tw-translate-x {
-  syntax: "*";
-  inherits: false;
-  initial-value: 0;
-}
-@property --tw-translate-y {
-  syntax: "*";
-  inherits: false;
-  initial-value: 0;
-}
-@property --tw-translate-z {
-  syntax: "*";
-  inherits: false;
-  initial-value: 0;
 }
 @property --tw-rotate-x {
   syntax: "*";
@@ -1061,9 +934,6 @@ html {
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
-      --tw-translate-x: 0;
-      --tw-translate-y: 0;
-      --tw-translate-z: 0;
       --tw-rotate-x: initial;
       --tw-rotate-y: initial;
       --tw-rotate-z: initial;

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <title>Parrothead 7s Rugby Tournament | Tulsa Rugby Club</title>
 
-    <meta name="description" content="Parrothead 7s – Compete in Oklahoma’s best rugby 7s tournament on July 12, 2025. Hosted by the Tulsa Rugby Club">
+    <meta name="description" content="Save the date for Parrothead 7s on July 18, 2026 in Tulsa, Oklahoma. Hosted by the Tulsa Rugby Club.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
@@ -34,7 +34,7 @@
     <meta property="og:url" content="https://parrothead-7s.netlify.app/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Parrothead 7s Rugby Tournament">
-    <meta property="og:description" content="Parrothead 7s – Compete in Oklahoma’s best rugby 7s tournament on July 12, 2025. Hosted by the Tulsa Rugby Club">
+    <meta property="og:description" content="Save the date for Parrothead 7s on July 18, 2026 in Tulsa, Oklahoma. Hosted by the Tulsa Rugby Club.">
     <meta property="og:image" content="https://parrothead-7s.netlify.app/images/teaser/share.jpg">
 
     <!-- Twitter Meta Tags -->
@@ -42,7 +42,7 @@
     <meta property="twitter:domain" content="parrothead-7s.netlify.app">
     <meta property="twitter:url" content="https://parrothead-7s.netlify.app/">
     <meta name="twitter:title" content="Parrothead 7s Rugby Tournament">
-    <meta name="twitter:description" content="Parrothead 7s – Compete in Oklahoma’s best rugby 7s tournament on July 12, 2025. Hosted by the Tulsa Rugby Club">
+    <meta name="twitter:description" content="Save the date for Parrothead 7s on July 18, 2026 in Tulsa, Oklahoma. Hosted by the Tulsa Rugby Club.">
     <meta name="twitter:image" content="https://parrothead-7s.netlify.app/images/teaser/share.jpg">
     <!-- <meta name="twitter:site" content="@200okconf"> -->
 
@@ -50,13 +50,6 @@
 </head>
 
 <body class="bg-[#fef0e5] rokkitt-400">
-    <!-- Rain Delay Header -->
-    <!-- <div class="bg-[#b84b3e] py-4">
-        <div class="max-w-screen-lg mx-auto px-8 text-center text-lg font-bold  leading-6 text-[#fef0e5] lg:flex lg:justify-center lg:items-center lg:gap-2 ">
-            <span class="block underline underline-offset-6 decoration-4 decoration-amber-900 lg:no-underline  md:inline-block lg:bg-amber-900 lg:py-0.5 lg:px-2 lg:rounded text-xl uppercase md:mr-2 lg:mr-0 mb-2 md:mb-0 ">Rain Delay!</span> <span class="inline-block  md:text-xl md:uppercase ">Please Check Updated <a class="underline underline-offset-6 decoration-3 decoration-amber-50" href="results.html">Schedule</a></span>
-        </div>
-    </div> -->
-
     <header class="md:sticky md:top-0 shadow-md z-20">
         <div class="bg-[#fab31b] ">
             <nav class="max-w-screen-lg mx-auto px-8">
@@ -64,42 +57,14 @@
                     <li>
                         <a class=" text-[#b84b3e] hover:text-[#db311d] underline underline-offset-6 decoration-4 decoration-[#b84b3e]  pr-2 sm:px-2 pb-px text-lg sm:text-xl" href="/">Home</a>
                     </li>
-                    <li>
-                        <a class="block text-[#b84b3e] hover:text-[#db311d] sm:pr-0 px-2 pb-px text-xl" href="#overview">
-                            <span class="sm:hidden">Details</span>
-                            <span class="hidden sm:inline-block">Details &amp; Rules</span>
-                        </a>
-                    </li>
-                    <!-- <li>
-                        <a class=" text-[#b84b3e] hover:text-[#db311d] hover:underline underline-offset-6 decoration-4 decoration-[#db311d]  pr-2 sm:px-2 pb-px text-lg sm:text-xl" href="results.html">2025 Results</a>
-                    </li> -->
-                    <li>
-                        <a class=" text-[#b84b3e] hover:text-[#db311d]  pr-2 sm:px-2 pb-px text-lg sm:text-xl" href="#map">Map</a>
-                    </li>
-                    <!-- TODO: Full Map Content -->
-                    <!-- <li>
-                        <a class=" text-[#b84b3e] hover:text-[#db311d]  pr-2 sm:px-2 pb-px text-lg sm:text-xl" href="#map">Map &amp; Parking</a>
-                    </li> -->
-                    <!-- TODO: Add Content -->
-                    <!-- <li>
-                        <a class="ml-2 sm:ml-0  text-[#b84b3e] hover:text-[#db311d] px-2 pb-px text-lg sm:text-xl" href="#faqs">FAQs</a>
-                    </li> -->
-                    <li class="hidden md:block">
-                        <a class="block text-[#b84b3e] hover:text-[#db311d] px-2 pb-px text-xl" href="#sponsors">Sponsors</a>
-                    </li>
-
-                    <!-- <li class="hidden lg:block">
-                        <a class="block text-[#b84b3e] hover:text-[#db311d] px-2 pb-px text-xl" href="#merch">Merch</a>
-                    </li> -->
-
                     <li class="hidden lg:block">
                         <a class="block  text-[#b84b3e] hover:text-[#db311d] px-2 pb-px text-xl" href="#tulsa">Tulsa RFC</a>
                     </li>
-                    <!-- <li class="">
+                    <li class="hidden sm:block">
                         <a class="block  text-[#b84b3e] hover:text-[#db311d] px-2 pb-px text-xl" href="#contact">Contact</a>
-                    </li> -->
+                    </li>
                     <li class="ml-auto">
-                        <a class="bg-[#b84b3e] hover:bg-[#db311d] text-stone-50 rounded px-4 py-1 text-xl" href="results.html">2025 Results</a>
+                        <a class="bg-[#b84b3e] hover:bg-[#db311d] text-stone-50 rounded px-4 py-1 text-xl" href="/register">Sign Up</a>
                     </li>
                 </ul>
             </nav>
@@ -116,23 +81,16 @@
         <section id="intro" class="max-w-screen-lg mx-auto px-8 text-center text-[#b84b3e] mb-8">
             <!-- mb-2 lg:mb-4 -->
             <h3 class="text-2xl md:text-3xl lg:text-4xl mb-8 uppercase flex gap-0 md:gap-6 flex-col md:flex-row justify-center w-full font-bold">
-                <span>Saturday, July 12, 2025</span>
+                <span>Saturday, July 18, 2026</span>
                 <span class="md:block hidden">/</span>
-                <span>Tulsa Rugby Pitch</span>
+                <span>Tulsa, OK</span>
             </h3>
 
             <div class="max-w-screen-md mx-auto px-8 mb-8 bg-[#fad86a]/40 rounded-2xl py-8">
                 <div class="flex flex-col gap-6 justify-center items-center text-xl">
-                    <div class="">Congratulations to our 2025 Parrot Head 7s Champions:
-                        <div class="text-xl lg:text-2xl font-bold">Fayetteville Phoenix (Women’s Division)</div>
-                        <div class="text-xl lg:text-2xl font-bold">Tulsa River Rats (Men’s Division)</div>
-                    </div>
-                    <p class="max-w-xl mx-auto">Thank you to all the teams, officials, volunteers, and fans who braved the weather and made this year’s tournament a success!</p>
-
-                    <p class="font-bold text-3xl leading-tight">Parrot Head 7s will return next summer. <span class="block">See you in 2026!</span></p>
-
-                    <!-- <a href="results.html" class="text-xl sm:text-2xl inline-block bg-[#4ca761]  text-[#fef0e5] rounded px-8 py-2 font-bold border-[#4ca761] border-2 ">View Tournament Schedule</a> -->
-                    <!-- <a href="/pay" class="text-xl sm:text-2xl inline-block border-2 text-[#4ca761] border-[#4ca761] hover:bg-[#318946] hover:border-[#318946]  hover:text-[#fef0e5] rounded px-8 py-2 font-bold" >Pay Registration Fee</a> -->
+                    <p class="font-bold text-3xl leading-tight">Save the date for Parrothead 7s.</p>
+                    <p class="max-w-xl mx-auto">Tournament details, venue information, brackets, and day-of schedules will be announced as the event gets closer.</p>
+                    <a href="/register" class="text-xl sm:text-2xl inline-block bg-[#4ca761] hover:bg-[#318946] text-[#fef0e5] rounded px-8 py-2 font-bold border-[#4ca761] border-2 ">Sign Up</a>
                 </div>
             </div>
         </section>
@@ -140,130 +98,37 @@
         <div class="px-4">
             <img class="mx-auto w-full max-w-3xl" src="/images/teaser/trees.png" alt="">
         </div>
-        <section id="overview" class="bg-[#fdd292] text-[#b84b3e]  py-12 md:pb-24">
-            <div class="max-w-screen-md mx-auto px-8">
-                <h2 class="text-4xl font-bold mb-4 ">Tournament Details</h2>
-                <p class="text-lg/6 mb-8">The men’s tournament will feature <strong>eight</strong> teams split into two pools of four. Each team will play three pool matches, followed by a knockout round where all teams are guaranteed at least one more game. The top teams will advance to the semifinals and finals.<br/><br/>The women’s tournament will include <strong>four</strong> teams in a single pool, playing round-robin style. The top two teams will advance to a final match.</p>
+        <!--
+            Future tournament content preserved for later phases:
 
+            Details:
+            The 2025 men’s tournament featured eight teams split into two pools of four.
+            Each team played three pool matches, followed by a knockout round where all
+            teams were guaranteed at least one more game. The top teams advanced to the
+            semifinals and finals. The women’s tournament included four teams in a single
+            pool, playing round-robin style, with the top two teams advancing to a final.
 
-                <a href="results.html" class="text-xl sm:text-2xl inline-block bg-[#4ca761]  text-[#fef0e5] rounded px-8 py-2 font-bold border-[#4ca761] border-2 ">View Tournament Results</a>
-            </div>
-        </section>
-        <section id="schedule" class="py-12 md:pb-24 hidden">
-            <div class="max-w-screen-md mx-auto px-8">
-                <h2 class="text-4xl font-bold mb-2">Tournament Location</h2>
+            Weather FAQ:
+            In accordance with USA Rugby guidelines, if lightning or thunder is detected,
+            play should be suspended immediately and players, coaches, and spectators
+            should shelter in vehicles. The prior venue had no permanent structures, so
+            vehicles were the safest nearby option. In case of a tornado warning or more
+            severe weather, participants were directed to reinforced buildings near the
+            41st Street Plaza at 41st & Riverside Drive.
 
-                <!-- Mens -->
-                <h3 class="text-3xl font-bold mb-2">Men's Bracket</h3>
-                <h4 class="text-2xl font-bold mb-2">Pools</h4>
-                <div class="mb-12 flex flex-col md:flex-row gap-8">
-                    <div class="border-2 mb-2 w-1/2">
-                        <span class="block text-center py-2 bg-black text-white text-2xl font-bold">Pool A</span>
-                        <ul class="m-0 text-center p-2">
-                            <li class="text-xl p-2 border-b-2">Team 1</li>
-                            <li class="text-xl p-2 border-b-2">Team 2</li>
-                            <li class="text-xl p-2 ">Team 3</li>
-                        </ul>
-                    </div>
-                    <div class="border-2 mb-2 w-1/2">
-                        <span class="block text-center py-2 bg-black text-white text-2xl font-bold">Pool B</span>
-                        <ul class="m-0 text-center p-2">
-                            <li class="text-xl p-2 border-b-2">Team 4</li>
-                            <li class="text-xl p-2 border-b-2">Team 5</li>
-                            <li class="text-xl p-2 ">Team 6</li>
-                        </ul>
-                    </div>
-                </div>
+            Parking FAQ:
+            Prior event parking used street parking in the neighborhoods east of the field,
+            limited parking at the 41st Street Plaza lot just south of the field, and
+            overflow parking at the Gathering Place gravel lot at 33rd Place & Riverside
+            Drive.
 
-                <!-- Womens -->
-                <h3 class="text-3xl font-bold mb-2">Women's Bracket</h3>
-            </div>
-        </section>
+            Prior sponsors:
+            Tequila Mi Campo, McNellie's Pub, Golden Arbor Tree Service.
 
-        <section id="faqs" class="bg-[#fef0e5] text-[#b84b3e]  py-12 md:pb-24">
-            <div class="max-w-screen-md mx-auto px-8">
-                <h2 class="text-4xl font-bold mb-6">FAQs</h2>
-                <ul class="flex flex-col gap-12">
-                    <li>
-                        <span class="block font-bold text-lg/5 mb-1">What happens if there’s lightning or severe weather?</span>
-                        <p>In accordance with <a target="_blank" href="docs/usar-lightning-policy.pdf" class="underline font-bold">USA Rugby guidelines</a>, if lightning or thunder is detected, play will be suspended immediately and all players, coaches, and spectators must shelter in their vehicles.
-
-                        <br/><br/>There are <strong>no permanent structures</strong> at the field, so vehicles are the safest nearby option. In case of a tornado warning or more severe weather, participants should evacuate to reinforced buildings near the 41st Street Plaza at 41st & Riverside Drive.</p>
-                    </li>
-                    <li>
-                        <span class="block font-bold text-lg/5 mb-1">Where should we park for the tournament?</span>
-                        <p>
-                            Street parking is available in the neighborhoods <strong>east of the field</strong>—please follow all posted signs and be respectful of residents. Limited parking is also available at the <strong>41st Street Plaza lot</strong> just south of the field.
-                            <br/><br/>Additional overflow parking can be found at the <strong>Gathering Place gravel lot</strong> at <strong>33rd Place & Riverside Drive</strong>, a short walk from the tournament area. If parking across Riverside Drive, <strong>use caution when crossing</strong>—stick to designated crosswalks and be alert to traffic.
-                        </p>
-                    </li>
-                    <!-- <li>
-                        <span class="block font-bold text-lg/5 mb-1">Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum?</span>
-                        <p>Ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
-                    </li> -->
-                </ul>
-            </div>
-        </section>
-        <section id="map" class=" py-12 md:pb-24 bg-[#fab31b]">
-             <div class="max-w-screen-md mx-auto px-8">
-                <h2 class="text-4xl font-bold mb-2">Tournament Location</h2>
-                <p class="mb-8 text-lg/6">This tournment will be held at the Tuls Rugby Club pitch — located in the Heart of the River Parks, directly south of the Gathering Place. It is located at <a class="underline decoration-2" href="https://maps.app.goo.gl/9Bo1TQyQtkxKamjz9">3772-3798 Riverside Dr, Tulsa, OK</a>.</p>
-                <!-- <div id="map" style="height: 400px;"></div> -->
-                 <!-- <iframe width="425" height="350" src="https://www.openstreetmap.org/export/embed.html?bbox=-95.98991990089418%2C36.10601714647418%2C-95.98013520240785%2C36.11253530758999&amp;layer=mapnik" style="border: 1px solid black"></iframe><br/><small><a href="https://www.openstreetmap.org/?#map=17/36.109276/-95.985028">View Larger Map</a></small> -->
-                  <div class="mb-12">
-                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d9195.908614007398!2d-95.98522784840182!3d36.11307200522428!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x87b694aa0a49e7bf%3A0x5add601f67359cfd!2sTulsa%20Rugby%20Pitch!5e0!3m2!1sen!2sus!4v1743318578239!5m2!1sen!2sus" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                  </div>
-
-                  <!-- <img src="images/sitemap.png" class="shadow-2xl border-16 border-[#b84b3e]"> -->
-
-                  <!-- TODO: Add Content -->
-                  <!-- <h3 class="text-4xl font-bold mb-2">Parking</h3>
-                  <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Veritatis laudantium corporis, nesciunt, fuga sed impedit delectus dolor ratione repudiandae commodi debitis cum reprehenderit. Dicta id voluptatum, alias unde dolor iste!</p> -->
-             </div>
-        </section>
-        <!-- Sponsors -->
-        <section id="sponsors" class=" bg-[#9cbc9c]  py-12 md:pb-24">
-            <div class="max-w-screen-md mx-auto px-8 text-center">
-                <h2 class="text-4xl font-bold mb-2">Sponsors</h2>
-                <p class="mb-2 text-lg/6 max-w-xl mx-auto">This tournament wouldn't be possible without the support of our incredible sponsors. Thank you for backing this event and Tulsa Rugby.</p>
-                <p class="mb-8 text-lg/6 max-w-xl mx-auto">If you would like to donate/sponsor us, please <a class="underline decoration-2" href="mailto:parrothead7s@tulsarugbyclub.com">contact us</a>.</p>
-                <ul class="flex gap-12 flex-col justify-center items-center">
-                    <li>
-                        <a class="" href="https://tequilamicampo.com/">
-                            <img class="w-full max-w-xs ml-4" src="/images/teaser/mi-campo.png" alt="Tequila Mi Campo">
-                        </a>
-                    </li>
-                    <li>
-                        <a class="" href="https://mcnellies.com/" target="_blank">
-                            <img class="w-full max-w-sm" src="/images/teaser/mcnellies.png" alt="McNellie's Pub">
-                        </a>
-                    </li>
-                    <li>
-                        <a class="" href="https://goldenarbortreeservice.com/" target="_blank">
-                            <img class="w-full max-w-md" src="/images/teaser/golden-arbor-v2.png" alt="Golden Arbor Tree Service">
-                        </a>
-                    </li>
-                </ul>
-            </div>
-        </section>
-        <!-- Merch -->
-        <section id="merch" class="bg-[#fef0e5] text-[#b84b3e]  py-12 md:pb-24 hidden">
-            <div class="max-w-screen-md mx-auto px-8">
-                <h2 class="text-4xl font-bold mb-2">Merch</h2>
-                <p class="mb-8 text-lg/6 ">
-                    Our official Parrot Head tournamnet Hawaiian shirt is availabe for pre-order. Order yours today and pick it up at the tournament!
-                </p>
-                <div class="flex gap-16 justify-center sm:justify-start">
-                    <div class="relative max-w-xs text-center z-0 ">
-                        <!-- <span class="-rotate-10 absolute left-1/2 top-1/2 -translate-1/2 block bg-[#fab31b] py-2 w-full text-center text-xl font-bold z-20">Coming Soon</span> -->
-                        <img class="w-full  mb-2" src="/images/teaser/shirt-mock.png" alt="Mockup of the Parrotheads 2025 Shirt">
-                        <span class="block  mb-8 italic text-sm leading-tight w-48 mx-auto">Note that final shirt design will include a Parrot Head TRFC patch on left chest. </span>
-                        <!-- <a class=" block w-full py-3 text-xl font-bold justify-center bg-[#00ab5a] xhover:bg-[#018a49] text-[#fef0e5] rounded px-4  mx-auto hover:bg-[#318946]" href="https://www.paypal.com/ncp/payment/UFU4V3J4Q3NGC" target="_blank">$65 Pre-order</a> -->
-                    </div>
-
-                </div>
-            </div>
-        </section>
+            Merch:
+            The prior Hawaiian shirt preorder copy and shirt mockup remain available in
+            source history and the image at /images/teaser/shirt-mock.png.
+        -->
         <!-- Tulsa Club -->
         <section id="tulsa" class="bg-rugby  py-12">
              <div class="max-w-screen-md mx-auto px-8 text-[#242c4c]">
@@ -283,7 +148,7 @@
          <section id="contact" class="bg-[#fef0e5] text-[#b84b3e]  py-12 md:pb-24">
             <div class="max-w-screen-md mx-auto px-8">
                 <h2 class="text-4xl font-bold mb-6">Contact</h2>
-                <p class="mb-8 text-lg/6">Got a question about the event, registration, or the game schedule? We’re here to help. Whether you’re a player, fan, or curious wanderer—we’d love to hear from you.</p>
+                <p class="mb-8 text-lg/6">Got a question about the event or registration? We’re here to help. Whether you’re a player, fan, or curious wanderer, we’d love to hear from you.</p>
                 <h3 class="text-2xl font-bold mb-2">Follow us:</h3>
                 <div class="flex gap-4 mb-8">
                     <a href="https://www.instagram.com/parrothead7s/" class="text-2xl hover:text-[#db311d]" ><i class="fa-brands fa-instagram"></i></a>
@@ -330,15 +195,13 @@
     </main>
     <footer class="py-3 text-right">
         <div class="max-w-screen-lg mx-auto px-8 text-yellow-80 opacity-50 italic">
-            &copy; 2025 Tulsa Rugby Club
+            &copy; 2026 Tulsa Rugby Club
         </div>
     </footer>
     <!-- <footer class="mt-8 max-w-screen-lg mx-auto px-8">
         <div class="plam-bg h-24 sm:h-42 md:h-72 lg:h-96"></div>
     </footer> -->
 
-    <!-- Put HTML Here -->
-    <script src="app.js"></script>
 </body>
 
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
 
 [[redirects]]
   from = "/pay"
-  to = "/"
+  to = "https://www.paypal.biz/tulsarugby"
   status = 302
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,29 +1,47 @@
 [[redirects]]
   from = "/register"
-  to = "/"
-  status = 301
+  to = "https://docs.google.com/forms/d/e/1FAIpQLSdCOQRf7f2p-tVSq5w6jIWUwdhFxy61Mj5KXD02jTXQhmHNQw/viewform?usp=dialog"
+  status = 302
   force = true
 
 [[redirects]]
   from = "/pay"
   to = "/"
-  status = 301
+  status = 302
   force = true
 
 [[redirects]]
   from = "/map"
-  to = "https://maps.app.goo.gl/4LTpxbKaCLoM8hoz9"
-  status = 301
+  to = "/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/results"
+  to = "/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/results.html"
+  to = "/"
+  status = 302
   force = true
 
 [[redirects]]
   from = "/qr"
-  to = "/results"
-  status = 301
+  to = "/"
+  status = 302
   force = true
 
 [[redirects]]
   from = "/schedule"
-  to = "/results"
-  status = 301
+  to = "/"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/schedule.html"
+  to = "/"
+  status = 302
   force = true


### PR DESCRIPTION
- Update homepage metadata, nav, hero copy, and signup CTA for July 18, 2026
- Hide event-specific sections while preserving later-use content in comments
- Redirect registration to the Google Form and lock old public routes back to the homepage
